### PR TITLE
Fix null pointer dereferences in codec

### DIFF
--- a/sound/soc/codecs/wcd9320.c
+++ b/sound/soc/codecs/wcd9320.c
@@ -1879,7 +1879,7 @@ static const struct soc_enum dec7_mux_enum =
 	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_TX_B2_CTL, 4, 7, dec7_mux_text);
 
 static const struct soc_enum dec8_mux_enum =
-	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_TX_B3_CTL, 0, 7, dec8_mux_text);
+	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_TX_B3_CTL, 0, 5, dec8_mux_text);
 
 static const struct soc_enum dec9_mux_enum =
 	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_TX_B3_CTL, 3, 8, dec9_mux_text);
@@ -1888,10 +1888,10 @@ static const struct soc_enum dec10_mux_enum =
 	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_TX_B4_CTL, 0, 8, dec10_mux_text);
 
 static const struct soc_enum anc1_mux_enum =
-	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_ANC_B1_CTL, 0, 16, anc_mux_text);
+	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_ANC_B1_CTL, 0, 15, anc_mux_text);
 
 static const struct soc_enum anc2_mux_enum =
-	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_ANC_B1_CTL, 4, 16, anc_mux_text);
+	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_ANC_B1_CTL, 4, 15, anc_mux_text);
 
 static const struct soc_enum anc1_fb_mux_enum =
 	SOC_ENUM_SINGLE(TAIKO_A_CDC_CONN_ANC_B2_CTL, 0, 3, anc1_fb_mux_text);

--- a/sound/soc/soc-dapm.c
+++ b/sound/soc/soc-dapm.c
@@ -269,6 +269,9 @@ out:
 static void dapm_set_path_status(struct snd_soc_dapm_widget *w,
 	struct snd_soc_dapm_path *p, int i)
 {
+	if (!p->name)
+		return;
+	
 	switch (w->id) {
 	case snd_soc_dapm_switch:
 	case snd_soc_dapm_mixer:


### PR DESCRIPTION
The null pointer dereferences causes the kernel to crash when compiled with Clang. The issue mostly originates from wcd9320, which causes a buffer overrun. Correct the array sizes to avoid such issue